### PR TITLE
Issue #10258 - Change default value of `optimize` arg

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -1057,7 +1057,7 @@ def einsum(*operands, **kwargs):
     """
 
     # Grab non-einsum kwargs
-    optimize_arg = kwargs.pop('optimize', False)
+    optimize_arg = kwargs.pop('optimize', True)
 
     # If no optimization, run pure einsum
     if optimize_arg is False:


### PR DESCRIPTION
As per issue #10258, the default value of the `optimize` arg is made consistent with the documentation, making it `True` by default